### PR TITLE
Add travis/downstream.sh script

### DIFF
--- a/travis/downstream.sh
+++ b/travis/downstream.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 REPOSITORY MESSAGE"
+    echo "Example: $0 environments \"Update Browser to 123456\""
+    echo "Depends on a TRAVIS_TOKEN environment variable"
+    exit 1
+fi
+
+repository="$1"
+message="$2"
+
+body='{
+    "request": {
+        "branch": "master",
+        "message": "'"$message"'"
+    }
+}'
+
+curl -s -X POST \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   -H "Travis-API-Version: 3" \
+   -H "Authorization: token $TRAVIS_TOKEN" \
+   -d "$body" \
+   "https://api.travis-ci.com/repo/libero%2F${repository}/requests"


### PR DESCRIPTION
A Travis CI build may need to trigger downstream builds of other repositories. For example, after a `browser` or `pattern-library` new commit on `master`, we eventually trigger `environments` to redeploy them.

This script is [extracted from browser](https://github.com/libero/browser/blob/master/.travis/downstream-environments.sh) and provides an API call that triggers another `libero/` build on its `master` branch. There isn't space for passing arguments to that build apart from a message which is an annotation on why that build is happening.