### PR TITLE
Push `latest` image tag

### DIFF
--- a/travis/push-image.sh
+++ b/travis/push-image.sh
@@ -21,6 +21,9 @@ if [[ "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     # tag temporarily as liberoadmin due to lack of `libero/` availability
     docker tag "libero/$project:$IMAGE_TAG" "liberoadmin/$project:$IMAGE_TAG"
     docker push "liberoadmin/$project:$IMAGE_TAG"
+    # push `latest` image
+    docker tag "libero/$project:$IMAGE_TAG" "liberoadmin/$project:latest"
+    docker push "liberoadmin/$project:latest"
 else
     echo "not pushing an image, we are not on master"
 fi


### PR DESCRIPTION
We are pushing consistently images through this script. 

The script only has a specific "master branch" case, since the builds of pull requests happen from forks and are not allowed to use credentials to push any Docker image.

We don't have a safety net of integration tests outside of the project's own Travis CI build, so the `after_success` stage this scripts runs in is reached after all available automated tests have been run.