### PR TITLE
Only perform health check if healthcheck status available

### DIFF
--- a/docker/wait-healthy.sh
+++ b/docker/wait-healthy.sh
@@ -15,6 +15,9 @@ timeout --foreground "$timeout" bash << EOT
     while true
     do
     current=\$(docker inspect "${container}" | jq -r '.[0].State.Health.Status')
+    if [ "\$current" == "null" ]; then
+        break
+    fi
     echo "${container} is in state: \${current}"
     if [ "\$current" == "$target" ]; then
         break


### PR DESCRIPTION
This allows us to pass any container identifier whether it has a healthcheck available or not. If there is no healthcheck available then it just moves on. If there is a heatlh status then it waits until it is healthy.