### PR TITLE
change retag-and-push behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ make test
 make teardown
 ```
 
+NOTE: some tests grep `docker images` output. If in doubt use `docker system prune --all` to ensure a clean test run.
 
 Getting help
 ------------

--- a/github/retag-and-push.sh
+++ b/github/retag-and-push.sh
@@ -31,8 +31,9 @@ fi
 if [[ "$GITHUB_REF" == "refs/heads"* ]]; then
     # push `branch-sha` tagged image
     branch="${GITHUB_REF/refs\/heads\//}"
-    docker tag "$input_image" "${name}:${branch}-${GITHUB_SHA}"
-    docker push "${name}:${branch}-${GITHUB_SHA}"
+    timestamp=$(date +%Y%m%d.%H%M)
+    docker tag "$input_image" "${name}:${branch}-${GITHUB_SHA}-${timestamp}"
+    docker push "${name}:${branch}-${GITHUB_SHA}-${timestamp}"
 
     if [[ "$branch" = "master" ]]; then
         # push `latest` tag

--- a/github/retag-and-push.sh
+++ b/github/retag-and-push.sh
@@ -31,7 +31,7 @@ fi
 if [[ "$GITHUB_REF" == "refs/heads"* ]]; then
     # push `branch-sha` tagged image
     branch="${GITHUB_REF/refs\/heads\//}"
-    timestamp=$(date +%Y%m%d.%H%M)
+    timestamp=$(date --utc +%Y%m%d.%H%M)
     short_sha=${GITHUB_SHA:0:8}
     docker tag "$input_image" "${name}:${branch}-${short_sha}-${timestamp}"
     docker push "${name}:${branch}-${short_sha}-${timestamp}"

--- a/github/retag-and-push.sh
+++ b/github/retag-and-push.sh
@@ -32,8 +32,11 @@ if [[ "$GITHUB_REF" == "refs/heads"* ]]; then
     # push `branch-sha` tagged image
     branch="${GITHUB_REF/refs\/heads\//}"
     timestamp=$(date +%Y%m%d.%H%M)
-    docker tag "$input_image" "${name}:${branch}-${GITHUB_SHA}-${timestamp}"
-    docker push "${name}:${branch}-${GITHUB_SHA}-${timestamp}"
+    short_sha=${GITHUB_SHA:0:8}
+    docker tag "$input_image" "${name}:${branch}-${short_sha}-${timestamp}"
+    docker push "${name}:${branch}-${short_sha}-${timestamp}"
+    docker tag "$input_image" "${name}:${branch}-${short_sha}"
+    docker push "${name}:${branch}-${short_sha}"
 
     if [[ "$branch" = "master" ]]; then
         # push `latest` tag

--- a/tests/github-push-image.bats
+++ b/tests/github-push-image.bats
@@ -3,7 +3,7 @@
 # Place the following before an assertion to debug the output
 # echo "output = ${output}"
 
-@test "valid master tagging" {
+@test "legacy master tagging" {
     export GITHUB_REF=refs/heads/master
     export IMAGE_TAG=12345678
     run docker tag busybox libero/my-dummy-project:12345678

--- a/tests/github-retag-and-push.bats
+++ b/tests/github-retag-and-push.bats
@@ -13,11 +13,13 @@ teardown () {
 
 @test "valid other branch" {
     export GITHUB_REF=refs/heads/foobar
-    export GITHUB_SHA=12345678
-    run docker tag busybox libero/otherbranch:12345678
-    run github/retag-and-push.sh otherbranch 12345678
+    export GITHUB_SHA=1234567890ab
+    run docker tag busybox libero/otherbranch:123
+    run github/retag-and-push.sh otherbranch 123
     [ "$status" -eq 0 ]
-    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/otherbranch\s*foobar-12345678-\d{8}\.\d{4}"
+    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/otherbranch\s*foobar-12345678-\d{8}\.\d{4}\s"
+    [ "$status" -eq 0 ]
+    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/otherbranch\s*foobar-12345678\s"
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/otherbranch:latest
     [ "$status" -eq 1 ]
@@ -25,9 +27,9 @@ teardown () {
 
 @test "valid master tagging" {
     export GITHUB_REF=refs/heads/master
-    export GITHUB_SHA=12345678
-    run docker tag busybox libero/my-dummy-project:12345678
-    run github/retag-and-push.sh my-dummy-project 12345678
+    export GITHUB_SHA=1234567890ab
+    run docker tag busybox libero/my-dummy-project:123
+    run github/retag-and-push.sh my-dummy-project 123
     [ "$status" -eq 0 ]
     docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/my-dummy-project\s*master-12345678-\d{8}\.\d{4}"
     [ "$status" -eq 0 ]
@@ -37,9 +39,9 @@ teardown () {
 
 @test "rename liberoadmin to libero" {
     export GITHUB_REF=refs/tags/v1.2.43
-    export GITHUB_SHA=12345678
-    run docker tag busybox liberoadmin/my-dummy-project:12345678
-    run github/retag-and-push.sh my-dummy-project 12345678
+    export GITHUB_SHA=1234567809ab
+    run docker tag busybox liberoadmin/my-dummy-project:123
+    run github/retag-and-push.sh my-dummy-project 123
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:1
     [ "$status" -eq 0 ]
@@ -49,7 +51,7 @@ teardown () {
 
 @test "valid semver tagging" {
     export GITHUB_REF=refs/tags/v1.2.43
-    export GITHUB_SHA=12345678
+    export GITHUB_SHA=1234567890ab
     run docker tag busybox libero/my-dummy-project:master-12345678
     run github/retag-and-push.sh my-dummy-project 12345678
     [ "$status" -eq 0 ]
@@ -63,7 +65,7 @@ teardown () {
 
 @test "missing v in tag" {
     export GITHUB_REF=refs/tags/1.2.43
-    export GITHUB_SHA=12345678
+    export GITHUB_SHA=1234567890ab
     run docker tag busybox libero/my-dummy-project:master-12345678
     run github/retag-and-push.sh my-dummy-project 12345678
     [ "$status" -eq 1 ]
@@ -73,7 +75,7 @@ teardown () {
 
 @test "invalid semver" {
     export GITHUB_REF=refs/tags/01.2.43
-    export GITHUB_SHA=12345678
+    export GITHUB_SHA=1234567890ab
     run docker tag busybox libero/my-dummy-project:master-12345678
     run github/retag-and-push.sh my-dummy-project 12345678
     [ "$status" -eq 1 ]

--- a/tests/github-retag-and-push.bats
+++ b/tests/github-retag-and-push.bats
@@ -11,25 +11,25 @@ teardown () {
 }
 
 
-@test "valid other branch" {
+@test "misc branch, shorten sha" {
     export GITHUB_REF=refs/heads/foobar
-    export GITHUB_SHA=1234567890ab
+    export GITHUB_SHA=shortsha-butwithlongbitpresent
     run docker tag busybox libero/otherbranch:123
     run github/retag-and-push.sh otherbranch 123
     [ "$status" -eq 0 ]
-    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/otherbranch\s*foobar-12345678-\d{8}\.\d{4}\s"
-    [ "$status" -eq 0 ]
-    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/otherbranch\s*foobar-12345678\s"
+    run docker pull "${DOCKER_REGISTRY}liberoadmin/otherbranch:foobar-shortsha"
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/otherbranch:latest
     [ "$status" -eq 1 ]
 }
 
-@test "valid master tagging" {
+@test "valid master tagging w/wo timestamp" {
     export GITHUB_REF=refs/heads/master
     export GITHUB_SHA=1234567890ab
     run docker tag busybox libero/my-dummy-project:123
     run github/retag-and-push.sh my-dummy-project 123
+    [ "$status" -eq 0 ]
+    run docker pull "${DOCKER_REGISTRY}liberoadmin/my-dummy-project:master-12345678"
     [ "$status" -eq 0 ]
     docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/my-dummy-project\s*master-12345678-\d{8}\.\d{4}"
     [ "$status" -eq 0 ]

--- a/tests/github-retag-and-push.bats
+++ b/tests/github-retag-and-push.bats
@@ -17,7 +17,7 @@ teardown () {
     run docker tag busybox libero/otherbranch:12345678
     run github/retag-and-push.sh otherbranch 12345678
     [ "$status" -eq 0 ]
-    run docker pull ${DOCKER_REGISTRY}liberoadmin/otherbranch:foobar-12345678
+    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/otherbranch\s*foobar-12345678-\d{8}\.\d{4}"
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/otherbranch:latest
     [ "$status" -eq 1 ]
@@ -29,19 +29,19 @@ teardown () {
     run docker tag busybox libero/my-dummy-project:12345678
     run github/retag-and-push.sh my-dummy-project 12345678
     [ "$status" -eq 0 ]
-    run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:master-12345678
+    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/my-dummy-project\s*master-12345678-\d{8}\.\d{4}"
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:latest
     [ "$status" -eq 0 ]
 }
 
 @test "rename liberoadmin to libero" {
-    export GITHUB_REF=refs/heads/master
+    export GITHUB_REF=refs/tags/v1.2.43
     export GITHUB_SHA=12345678
     run docker tag busybox liberoadmin/my-dummy-project:12345678
     run github/retag-and-push.sh my-dummy-project 12345678
     [ "$status" -eq 0 ]
-    run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:master-12345678
+    run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:1
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:latest
     [ "$status" -eq 0 ]

--- a/tests/github-retag-and-push.bats
+++ b/tests/github-retag-and-push.bats
@@ -13,11 +13,11 @@ teardown () {
 
 @test "misc branch, shorten sha" {
     export GITHUB_REF=refs/heads/foobar
-    export GITHUB_SHA=shortsha-butwithlongbitpresent
+    export GITHUB_SHA=2605e072add62ffed33adf8758fd9d5e7daeca7c
     run docker tag busybox libero/otherbranch:123
     run github/retag-and-push.sh otherbranch 123
     [ "$status" -eq 0 ]
-    run docker pull "${DOCKER_REGISTRY}liberoadmin/otherbranch:foobar-shortsha"
+    run docker pull "${DOCKER_REGISTRY}liberoadmin/otherbranch:foobar-2605e072"
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/otherbranch:latest
     [ "$status" -eq 1 ]
@@ -25,13 +25,13 @@ teardown () {
 
 @test "valid master tagging w/wo timestamp" {
     export GITHUB_REF=refs/heads/master
-    export GITHUB_SHA=1234567890ab
+    export GITHUB_SHA=2605e072add62ffed33adf8758fd9d5e7daeca7c
     run docker tag busybox libero/my-dummy-project:123
     run github/retag-and-push.sh my-dummy-project 123
     [ "$status" -eq 0 ]
-    run docker pull "${DOCKER_REGISTRY}liberoadmin/my-dummy-project:master-12345678"
+    run docker pull "${DOCKER_REGISTRY}liberoadmin/my-dummy-project:master-2605e072"
     [ "$status" -eq 0 ]
-    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/my-dummy-project\s*master-12345678-\d{8}\.\d{4}"
+    docker images | grep -P "${DOCKER_REGISTRY}liberoadmin/my-dummy-project\s*master-2605e072-\d{8}\.\d{4}"
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:latest
     [ "$status" -eq 0 ]
@@ -39,9 +39,8 @@ teardown () {
 
 @test "rename liberoadmin to libero" {
     export GITHUB_REF=refs/tags/v1.2.43
-    export GITHUB_SHA=1234567809ab
-    run docker tag busybox liberoadmin/my-dummy-project:123
-    run github/retag-and-push.sh my-dummy-project 123
+    run docker tag busybox liberoadmin/my-dummy-project:2605e072
+    run github/retag-and-push.sh my-dummy-project 2605e072
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:1
     [ "$status" -eq 0 ]
@@ -51,9 +50,8 @@ teardown () {
 
 @test "valid semver tagging" {
     export GITHUB_REF=refs/tags/v1.2.43
-    export GITHUB_SHA=1234567890ab
-    run docker tag busybox libero/my-dummy-project:master-12345678
-    run github/retag-and-push.sh my-dummy-project 12345678
+    run docker tag busybox libero/my-dummy-project:master-2605e072
+    run github/retag-and-push.sh my-dummy-project 2605e072
     [ "$status" -eq 0 ]
     run docker pull ${DOCKER_REGISTRY}liberoadmin/my-dummy-project:1
     [ "$status" -eq 0 ]
@@ -65,9 +63,8 @@ teardown () {
 
 @test "missing v in tag" {
     export GITHUB_REF=refs/tags/1.2.43
-    export GITHUB_SHA=1234567890ab
-    run docker tag busybox libero/my-dummy-project:master-12345678
-    run github/retag-and-push.sh my-dummy-project 12345678
+    run docker tag busybox libero/my-dummy-project:master-2605e072
+    run github/retag-and-push.sh my-dummy-project 2605e072
     [ "$status" -eq 1 ]
     [ "${lines[-2]}" = "refs/tags/1.2.43 is neither a branch head or valid semver tag" ]
     [ "${lines[-1]}" = "No image tagging or pushing was performed because of this." ]
@@ -75,9 +72,8 @@ teardown () {
 
 @test "invalid semver" {
     export GITHUB_REF=refs/tags/01.2.43
-    export GITHUB_SHA=1234567890ab
-    run docker tag busybox libero/my-dummy-project:master-12345678
-    run github/retag-and-push.sh my-dummy-project 12345678
+    run docker tag busybox libero/my-dummy-project:master-2605e072
+    run github/retag-and-push.sh my-dummy-project 2605e072
     [ "$status" -eq 1 ]
     [ "${lines[-2]}" = "refs/tags/01.2.43 is neither a branch head or valid semver tag" ]
 }


### PR DESCRIPTION
Implements the proposed change to libero/ADR#9. See libero/community/pull/38.  
Should only be merged if proposed change gets accepted at sync meeting.

To see how the addition of a timestamp allows for the use of renovatebot see my [sandbox repo](https://github.com/erkannt/renovate_sandbox).

- add timestamp to tag
- use grep instead of docker pull to check for success

Need to regex the resulting image tag to avoid race condition where the time ticks over between tagging and test.